### PR TITLE
Check if is a known creature to prevent debug assertions on tibia client

### DIFF
--- a/src/protocolspectator.cpp
+++ b/src/protocolspectator.cpp
@@ -184,6 +184,10 @@ void ProtocolSpectator::syncKnownCreatureSets()
 	bool known;
 	uint32_t removedKnown;
 	for (const auto creatureID : casterKnownCreatures) {
+		if (knownCreatureSet.find(creatureID) != knownCreatureSet.end()) {
+			continue;
+		}
+
 		NetworkMessage msg;
 		const auto creature = g_game.getCreatureByID(creatureID);
 		if (creature && !creature->isRemoved()) {


### PR DESCRIPTION
It is needed, if you login with tibia client every creature on screen is readded on playerPos but it was already added before the sync with removes the creature on screen for spectators